### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
   self.presentViewController(UINavigationController(rootViewController: colorPickerController), animated: true, completion: nil)
 ```
 ## Requirements
-iOS 8+, XCode 7+
+iOS 8+, Xcode 7+
 
 (Included via pod dependency):
 * ChameleonFramework


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
